### PR TITLE
fixes #12 Ability to provide remote name as part of branch name

### DIFF
--- a/index.js
+++ b/index.js
@@ -394,7 +394,6 @@ function createMergeRequest(options) {
                       target_project_id: targetProjectId
                     }, function (err, response, body) {
                       var mergeRequestResponse = response.body;
-                      console.log('mergeRequestResponse : ', mergeRequestResponse);
                       if (mergeRequestResponse.iid) {
                         open(gitlabURL + "/" + targetProjectName + "/merge_requests/" + mergeRequestResponse.iid + (!!options.edit ? '/edit' : ''));
                         return;

--- a/index.js
+++ b/index.js
@@ -96,8 +96,8 @@ function parseBranchRemoteInfo(branchName){
         var splits = branchName.split('/');
         var maybeRemote = splits[0].trim();
         var remoteName = null;
-        if(allRemotes.indexOf(maybeRemote)){
-          branchName = splits[1];
+        if(allRemotes.indexOf(maybeRemote) != -1){
+          branchName = splits.slice(1).join("/");
           remoteName = maybeRemote;
         }
         logger.log('Branch name obtained :', branchName.green);
@@ -154,6 +154,7 @@ function getTargetBranchName(branchName){
 
 function getRemoteForBranch(branchName) {
   logger.log('\nGetting remote of branch  :', branchName);
+
 
   var promise = new Promise(function (resolve, reject) {
 

--- a/index.js
+++ b/index.js
@@ -394,7 +394,7 @@ function createMergeRequest(options) {
                       target_project_id: targetProjectId
                     }, function (err, response, body) {
                       var mergeRequestResponse = response.body;
-                      logger.log('merge request response : \n\n', mergeRequestResponse);
+                      logger.log('Merge request response : \n\n', mergeRequestResponse);
 
                       if (mergeRequestResponse.iid) {
                         open(gitlabURL + "/" + targetProjectName + "/merge_requests/" + mergeRequestResponse.iid + (!!options.edit ? '/edit' : ''));

--- a/index.js
+++ b/index.js
@@ -394,6 +394,8 @@ function createMergeRequest(options) {
                       target_project_id: targetProjectId
                     }, function (err, response, body) {
                       var mergeRequestResponse = response.body;
+                      logger.log('merge request response : \n\n', mergeRequestResponse);
+
                       if (mergeRequestResponse.iid) {
                         open(gitlabURL + "/" + targetProjectName + "/merge_requests/" + mergeRequestResponse.iid + (!!options.edit ? '/edit' : ''));
                         return;


### PR DESCRIPTION
This fixes https://github.com/vishwanatharondekar/gitlab-cli/issues/12 

This PR tries to figure out if branch name contains remote and uses that. This includes lot of changes and need to be tested thoroughly before merging.

You can create merge request between forks like following 

```
gitlab-cli create-merge-request -b origin/develop -t upstream/develop
```