### PR TITLE
fix: create web url yourself if not available in response

### DIFF
--- a/index.js
+++ b/index.js
@@ -413,7 +413,12 @@ function createMergeRequest(options) {
                       logger.log('Merge request response : \n\n', mergeRequestResponse);
 
                       if (mergeRequestResponse.iid) {
-                        var mergeRequestUrl = mergeRequestResponse.web_url + (!!options.edit ? '/edit' : '');
+                        var urlToOpen = mergeRequestResponse.web_url;
+                        if(!urlToOpen){
+                          urlToOpen = gitlabURL + "/" + targetProjectName + "/" + "/merge_requests/" + mergeRequestResponse.iid
+                        }
+
+                        var mergeRequestUrl = urlToOpen + (!!options.edit ? '/edit' : '');
                         if (options.print) {
                           console.log(mergeRequestUrl);
                         } else {


### PR DESCRIPTION
gitlab api stopped giving web url. Creating URL from the data available.