### PR TITLE
Always output commands with help

### DIFF
--- a/index.js
+++ b/index.js
@@ -334,10 +334,7 @@ function openMergeRequests(options) {
   })
 }
 
-
-
 function createMergeRequest(options) {
-
   logger = log.getInstance(options.verbose);
   if(options.verbose){
     logger.log('verbose option used. Detailed logging information will be emitted.'.green);
@@ -473,25 +470,6 @@ program
   .version('0.0.1')
   .description('gitlab command line for creating merge request.')
 
-if (!process.argv.slice(2).length) {
-  program.outputHelp();
-  process.exit(1);
-}
-
-var commandsSupported = [
-  'create-merge-request',
-  'browse',
-  'compare',
-  'open-merge-requests'
-];
-
-var command = process.argv.slice(2)[0];
-
-if (commandsSupported.indexOf(command.trim()) == -1) {
-  console.error(("Invalid command" + " " + command).red);
-  program.outputHelp();
-}
-
 program
   .command('create-merge-request')
   .option('-b, --base [optional]', 'Base branch name')
@@ -535,7 +513,17 @@ program
     openMergeRequests(options);
   });
 
+program
+  .on('command:*', function() {
+    console.error(('Invalid command ' + program.args[0]).red);
+    program.outputHelp();
+  });
+
 program.parse(process.argv);
+
+if (program.args.length < 1) {
+  program.outputHelp();
+}
 
 module.exports = function () {
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "colors": "^1.1.2",
-    "commander": "^2.9.0",
+    "commander": "^2.12.1",
     "dotenv": "^4.0.0",
     "editor": "^1.0.0",
     "gitlab": "^1.7.1",


### PR DESCRIPTION
A couple of bugs occurred because of the early error handling which is now at the end:

- outputHelp won't include the commands list if you haven't defined the commands yet
- invalid commands would cause double outputHelp calls

Also you can rely on `command:*` to match any undefined commands, saves listing them twice