### PR TITLE
fix: regular expression changed to allow everything in project name

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ var open = require("open");
 var Promise = require('promise');
 var URL = require('url');
 var colors = require('colors');
-var regexParseProjectName = /(.+:\/\/.+?\/|.+:)(.+\/[\w]+)+.git/;
+var regexParseProjectName = /(.+:\/\/.+?\/|.+:)(.+\/.+)+.git/;
 
 if (!process.env.GITLAB_URL) {
   console.error(colors.red('Env variable GITLAB_URL is not set. Please set env variable GITLAB_URL'));


### PR DESCRIPTION
Project name was restrictive of only characters. This was breaking for projects names with special characters like hyphen (-) in them.