### PR TITLE
Git config and onboarding

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,17 +29,20 @@ var git = {
 
 var gitlab = require('gitlab')((function () {
   var options = {
-    url: git.config.get('gitlab.url') || process.env.GITLAB_URL || (function (remote) {
-      var url = git.config.get('remote.origin.url');
-      return url && 'https://' + gitUrlParse(url).resource;
-    })(),
+    url: git.config.get('gitlab.url') || process.env.GITLAB_URL,
     token: git.config.get('gitlab.token') || process.env.GITLAB_TOKEN,
   };
 
   if (!options.url) {
-    var question = 'Enter GitLab URL: '.yellow;
+    var question = 'Enter GitLab URL';
+    var defaultInput = (function () {
+      var url = git.config.get('remote.origin.url');
+      return url && 'https://' + gitUrlParse(url).resource;
+    })();
+    if (defaultInput) question += ' (' + defaultInput + ')';
+    question = (question + ': ').yellow;
     while (!options.url) {
-      options.url = readlineSync.question(question);
+      options.url = readlineSync.question(question, { defaultInput: defaultInput });
       question = 'Invalid URL (try again): '.red
     }
     git.config.set('gitlab.url', options.url);

--- a/package.json
+++ b/package.json
@@ -16,8 +16,10 @@
     "commander": "^2.12.1",
     "dotenv": "^4.0.0",
     "editor": "^1.0.0",
+    "git-url-parse": "^7.0.1",
     "gitlab": "^1.7.1",
     "open": "0.0.5",
-    "promise": "^7.1.1"
+    "promise": "^7.1.1",
+    "readline-sync": "^1.4.7"
   }
 }


### PR DESCRIPTION
- Supports pulling `gitlab.url` and `gitlab.token` out of git config
- Onboards the user asking for these values and setting them in git config
- Tries env vars if no config ahead before trying onboarding
- Tries guessing the url from `origin` remote if no env vars

A future work could be to add a `config` command or similar to change these values after they're first set, but for now I haven't done that - should probably put some help text somewhere so people know how to change them if they muck them up

Also note there's no validation of either value presently