### PR TITLE
Support remotes not ending in .git

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ var projectDir = process.cwd();
 var Promise = require('promise');
 var URL = require('url');
 var readlineSync = require('readline-sync');
-var regexParseProjectName = /(.+:\/\/.+?\/|.+:)(.+\/.+)+.git/;
+var regexParseProjectName = /^([^:]+:\/\/[^\/]+?\/|[^:]+:)([^\/]+\/[^\/]+?)(?:\.git)?\s*$/;
 
 var git = {
   config: {
@@ -389,7 +389,7 @@ function createMergeRequest(options) {
         if (match) {
           var projectName = match[2];
         } else {
-          console.error(colors.red('Remote at which ' + baseBranch + ' is tracked, It\'s URL doesn\'t seem to end with .git . It is assumed that your remote URL will end with .git in this utility. '));
+          console.error(colors.red('The remote at which ' + baseBranch + ' is tracked doesn\'t match the expected format.'));
           console.log('Please contact developer if this is a valid gitlab repository.');
           process.exit(1);
         }
@@ -418,7 +418,7 @@ function createMergeRequest(options) {
                 if (targetMatch) {
                   var targetProjectName = targetMatch[2];
                 } else {
-                  console.error(colors.red('Remote at which ' + targetBranch + ' is tracked, It\'s URL doesn\'t seem to end with .git . It is assumed that your remote URL will end with .git in this utility. '));
+                  console.error(colors.red('The remote at which ' + targetBranch + ' is tracked doesn\'t match the expected format.'));
                   console.log('Please contact developer if this is a valid gitlab repository.');
                   process.exit(1);
                 }


### PR DESCRIPTION
The .git suffix is entirely unnecessary, and I am not in the habit of having it; I see no reason why this project should require it.

The critical part in the regexParseProjectName change is anchoring the match to the end of the string (`$`) and making the project name matching non-greedy (adding `?` after `.+`) so that an optional `.git` would consume that part, rather than the project name including `.git`. But I also substantially improved the regular expression while I was at it to make it much more robust.

(This supersedes #65 which got broken by shenanigans I was doing, and GitHub won’t let me reopen it due to the nature of some of those shenanigans.)