### PR TITLE
Fix 404 not found while creating a merge request

### DIFF
--- a/index.js
+++ b/index.js
@@ -248,7 +248,8 @@ function compare(options) {
       getURLOfRemote(remote).then(function (remoteURL) {
 
         var projectName = remoteURL.match(regexParseProjectName)[2];
-        gitlab.Projects.show(projectName).then(function (project) {
+        gitlab.Projects.search(projectName).then(function (project) {
+          project = project[0];
           var defaultBranch = project.default_branch;
           var targetBranch = options.target || defaultBranch;
           var sourceBranch = baseBranch;
@@ -366,8 +367,9 @@ function createMergeRequest(options) {
     logger.log('\nProject name derived from host :', projectName);
     logger.log('\nGetting gitlab project info for :', projectName);
     store.set({sourceRemoteURL : remoteURL})
-    return gitlab.Projects.show(projectName)
+    return gitlab.Projects.search(projectName)
   }).then(function (project) {
+    project = project[0];
     logger.log('Base project info obtained :', JSON.stringify(project).green);
 
     var defaultBranch = project.default_branch;
@@ -399,9 +401,10 @@ function createMergeRequest(options) {
 
     logger.log('Getting target project information');
     store.set({targetRemoteUrl : targetRemoteUrl})
-    return gitlab.Projects.show(targetProjectName)
+    return gitlab.Projects.search(targetProjectName)
   })
   .then(function (targetProject) {
+    targetProject = targetProject[0];
     logger.log('Target project info obtained :', JSON.stringify(targetProject).green);
 
     var targetProjectId = targetProject.id;


### PR DESCRIPTION
Here is the error while creating the MR:
`
lab mr -b dev -t master -m 'merge request' -s -v -o
Verbose option used. Detailed logging information will be emitted.

Getting base branch information

Getting base branch name : 
Argument provided : dev
Base branch name obtained : dev

Getting remote of branch : dev
Executing git config branch.dev.remote
Remote obtained : origin


Getting URL of remote : origin
Executing  git config remote.origin.url
URL of remote obtained : ssh://git@xxxx.com/xxxx/xxxx/xxxx.git


gitlab host obtained : xxxx.com

Project name derived from host : xxxx/xxxx/xxxx

Getting gitlab project info for : xxxx/xxxx/xxxx

Searching project name matching : xxxx/xxxx/xxxx

Searching project name matching : xxxx/xxxx/xxxx
Couldn't create merge request
404 - {"message":"404 Project Not Found"}
`
I'm running gitlab version 12.9.2.

Signed-off-by: Lord-Y <Lord-Y@users.noreply.github.com>